### PR TITLE
Skip existing files on extraction

### DIFF
--- a/package.go
+++ b/package.go
@@ -2,7 +2,9 @@ package rbxbin
 
 import (
 	"archive/zip"
+	"bytes"
 	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -84,17 +86,68 @@ func (p *Package) Extract(src, dir string) error {
 }
 
 func unzipFile(src *zip.File, name string) error {
-	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, src.Mode())
+	f, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE, src.Mode())
 	if err != nil {
 		return err
 	}
 	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	if info.Size() > 0 {
+		// Compare the zip file's hash against the existing file, if they are
+		// identical, don't extract and just skip the file to save on writing.
+		identical, err := func() (bool, error) {
+			z, err := src.Open()
+			if err != nil {
+				return false, err
+			}
+			defer z.Close()
+
+			hasher := sha256.New()
+
+			io.Copy(hasher, f)
+			originHash := hasher.Sum(nil)
+
+			hasher.Reset()
+
+			io.Copy(hasher, z)
+			targetHash := hasher.Sum(nil)
+
+			if bytes.Compare(originHash[:], targetHash[:]) == 0 {
+				return true, nil
+			}
+
+			return false, nil
+		}()
+
+		if err != nil {
+			return err
+		}
+
+		if identical {
+			return nil
+		}
+	}
 
 	z, err := src.Open()
 	if err != nil {
 		return err
 	}
 	defer z.Close()
+
+	err = f.Truncate(0)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
 
 	if _, err := io.Copy(f, z); err != nil {
 		return err


### PR DESCRIPTION
This PR makes it so that, on extraction, if the target file already exists on the destination, we compare it's hash to the zipped file and only overwrite it if it's different. This does incur a read cost for every existing file, but it should theoretically save on writing.